### PR TITLE
feat(flashback WebUI): [6] setup web interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ test:
 
 lint:
 	go vet  src/*.go
+
+localdev: build
+	ALBUMDIRS="data/pic-sample/" ./flashback

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd // indirect
 	github.com/evanoberholster/imagemeta v0.0.1
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd // indirect
+	github.com/sirupsen/logrus v1.8.1
 	github.com/xiam/exif v0.0.0-20160817012543-33e82e3db72f // indirect
 )

--- a/src/albums-webui.go
+++ b/src/albums-webui.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Page struct for the web server
+type Page struct {
+	Title string
+	Body  []byte
+}
+
+// AlbumWebUI web interface for the UI
+type AlbumWebUI struct {
+	album  *Albums
+	logger *logrus.Entry
+}
+
+// NewAlbumWebUI , return Albums struct
+func NewAlbumWebUI(album *Albums, logger *logrus.Entry) *AlbumWebUI {
+	return &AlbumWebUI{
+		album:  album,
+		logger: logger,
+	}
+}
+
+// RunWebSrv , provide the web interface
+func (a *AlbumWebUI) RunWebSrv() {
+	http.HandleFunc("/", a.viewHandler)
+	a.logger.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func (a *AlbumWebUI) loadPage(url string) (*Page, error) {
+
+	if url == "/" {
+		body := "Welcom to the flashback album  <br>"
+		body = body + " We have " + strconv.Itoa(a.album.numPic) + " pictures in the album"
+		return &Page{Title: url, Body: []byte(body)}, nil
+	}
+
+	return &Page{Title: url, Body: []byte("Not expected for now")}, nil
+}
+
+func (a *AlbumWebUI) viewHandler(w http.ResponseWriter, r *http.Request) {
+	title := r.URL.Path
+	p, _ := a.loadPage(title)
+	fmt.Fprintf(w, "<h1>%s</h1><div>%s</div>", p.Title, p.Body)
+}
+
+// LoadAlbums , provide a mecanismes to load pictures in the album
+func (a *AlbumWebUI) LoadAlbums(logger *logrus.Entry) {
+	logger.Debug("Load All pics:")
+	numLoadedPic, err := a.album.LoadPhotosInAlbums()
+	logger.Infof("We have loaded : %d , in directory : %s", numLoadedPic, album.directoryPaths)
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+}

--- a/src/main.go
+++ b/src/main.go
@@ -2,32 +2,76 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
+
+// global variable to make it available in the web service
+var album *Albums
+
+// getEnv retreieve environnement variable or a default value.
+func getenv(key, defaultValue string) string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+	return value
+}
+
+// Page struct for the web server
+type Page struct {
+	Title string
+	Body  []byte
+}
 
 func main() {
 
-	if len(os.Args) < 2 {
-		fmt.Println("Arg required, path to a directory where your pick are")
+	// Logger
+	logrus := log.NewEntry(log.New())
+
+	// retrieve variable environnement and define default value if not present
+	envAlbumDirs := getenv("ALBUMDIRS", "./data/pic-sample/dir1,./data/pic-sample/dir1")
+	albumDirs := strings.Split(envAlbumDirs, ",")
+
+	if len(albumDirs) < 1 {
+		logrus.Errorf("ERROR: The album directory is empty: %s - please set Env variable ALBUMSDIRS", envAlbumDirs)
 		os.Exit(1)
 	}
 
-	// get file path
-	dirPictures := os.Args[1]
+	album = NewAlbum(albumDirs)
+	go loadAlbums(logrus)
 
-	album := NewAlbum([]string{dirPictures})
+	http.HandleFunc("/", viewHandler)
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
 
-	fmt.Println("Load All pics:")
+func loadPage(url string) (*Page, error) {
+
+	if url == "/" {
+		body := "Welcom to the flashback album  <br>"
+		body = body + " We have " + strconv.Itoa(album.numPic) + " pictures in the album"
+		return &Page{Title: url, Body: []byte(body)}, nil
+	}
+
+	return &Page{Title: url, Body: []byte("Not expected for now")}, nil
+}
+
+func viewHandler(w http.ResponseWriter, r *http.Request) {
+	title := r.URL.Path
+	p, _ := loadPage(title)
+	fmt.Fprintf(w, "<h1>%s</h1><div>%s</div>", p.Title, p.Body)
+}
+
+func loadAlbums(logger *logrus.Entry) {
+	logger.Debug("Load All pics:")
 	numLoadedPic, err := album.LoadPhotosInAlbums()
+	logger.Infof("We have loaded : %d , in directory : %s", numLoadedPic, album.directoryPaths)
 
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("We have loaded : %d , in directory : %s", numLoadedPic, dirPictures)
-
-	err = album.PrintAlbumInfo()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
I start running out of time for the project I try to accelerate but it's exactly the time to not rushing myself. 
It will be the last PR around the golang code. The next step will be focussing on documentation to explain the next step for this project. 

This PR includes the web UI for flashback, sadly I only provide the / page. This page shows the number of pictures loaded at the start-up. 
I would like to have 2 sub URLs: 
* /Week-number ( example HTTP://127.0.0.1:8080/52 to get pictures for the last week of the years) 
* /YYYY-MM-DD ( example HTTP://127.0.0.1:8080/2021-12-29 to get all pictures for the last week of the years)

it will not happen this weekend sadly :) .